### PR TITLE
Minimal Linux Proton Support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -750,15 +750,16 @@ ipcMain.on("exportModsToClipboard", async (event, mods: Mod[]) => {
 
 ipcMain.on("startGame", async (event, mods: Mod[], startGameOptions: StartGameOptions, saveName?: string) => {
   const appDataPath = app.getPath("userData");
-  const userScriptPath = `${appData.gamePath}\\my_mods.txt`;
+  const userScriptPath = nodePath.join(appData.gamePath, "my_mods.txt");
 
   const sortedMods = sortByNameAndLoadOrder(mods);
   const enabledMods = sortedMods.filter((mod) => mod.isEnabled);
 
+  const linuxBit = process.platform === "linux" ? "Z:" : "";
   const dataMod: Mod = {
     humanName: "",
     name: "data.pack",
-    path: `${appData.dataFolder}\\data.pack`,
+    path: nodePath.join(appData.dataFolder as string, "data.pack"),
     imgPath: "",
     workshopId: "",
     isEnabled: true,
@@ -778,14 +779,13 @@ ipcMain.on("startGame", async (event, mods: Mod[], startGameOptions: StartGameOp
     startGameOptions.isScriptLoggingEnabled ||
     startGameOptions.isSkipIntroMoviesEnabled
   ) {
-    await fs.mkdir(`${appDataPath}\\tempPacks`, { recursive: true });
+    await fs.mkdir(nodePath.join(appDataPath, "tempPacks"), { recursive: true });
 
     // const data = await readPacks(enabledMods.map((mod) => mod.path));
     const tempPackName = "!!!!out.pack";
-    const tempPackPath = `${appDataPath}\\tempPacks\\${tempPackName}`;
+    const tempPackPath = nodePath.join(appDataPath, "tempPacks", tempPackName);
     await writePack(appData.packsData, tempPackPath, enabledMods.concat(dataMod), startGameOptions);
-
-    extraEnabledMods = `\nadd_working_directory "${appDataPath}\\tempPacks";` + `\nmod "${tempPackName}";`;
+    extraEnabledMods = `\nadd_working_directory "${linuxBit + nodePath.join(appDataPath, "tempPacks")}";` + `\nmod "${tempPackName}";`;
   }
 
   const modPathsInsideMergedMods = enabledMods
@@ -800,12 +800,12 @@ ipcMain.on("startGame", async (event, mods: Mod[], startGameOptions: StartGameOp
   const text =
     enabledModsWithoutMergedInMods
       .filter((mod) => nodePath.relative(appData.dataFolder as string, mod.modDirectory) != "")
-      .map((mod) => `add_working_directory "${mod.modDirectory}";`)
+      .map((mod) => `add_working_directory "${linuxBit + mod.modDirectory}";`)
       .concat(enabledModsWithoutMergedInMods.map((mod) => `mod "${mod.name}";`))
       .join("\n") + extraEnabledMods;
 
   await fs.writeFile(userScriptPath, text);
-  const batPath = `${appDataPath}\\game.bat`;
+  const batPath = nodePath.join(appDataPath, "game.bat");
   let batData = `start /d "${appData.gamePath}" Warhammer3.exe`;
   if (saveName) {
     batData += ` game_startup_mode campaign_load "${saveName}" ;`;


### PR DESCRIPTION
Currently finds the game on Linux and creates working my_mods.txt for Proton use

Starting/continuing/etc. the game won't work since no Proton (or wine) is being called.
But the my_mods.txt is created and can then be applied via Steam launch options for WH3.
Useful for when the normal WH3 launcher refuses to work.

NOT suitable for use with the native Linux version - although making it so would likely only need smaller modification in addition to the ones in this PR.

I have not tested these changes on Windows (since I don't run Windows on this PC), so please do so before accepting the PR.

I only replaced use of the Windows \\-paths with the cross-platform compatible path.join() and added "Z:" to the paths in the my_mods.txt if the mod manager is running on Linux (needed for Proton).
Also not using the Registry on Linux of course, instead assuming standard Steam install path.
Should work just fine on Windows still, but better safe than sorry.