### PR TITLE
Add a search input to the Saved Games modal

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -394,5 +394,6 @@
   "upload": "Upload",
   "showHiddenSkills": "Show Hidden Skills",
   "showHiddenModifiersInsideSkills": "Show Hidden Modifiers Inside Skills",
-  "options": "Options"
+  "options": "Options",
+  "searchSaves": "Search Saved Files"
 }

--- a/src/flowbite/components/Modal/ModalBody.tsx
+++ b/src/flowbite/components/Modal/ModalBody.tsx
@@ -1,5 +1,5 @@
 import classNames from "classnames";
-import type { ComponentProps, FC, PropsWithChildren } from "react";
+import type { ComponentProps, FC, HTMLProps, PropsWithChildren } from "react";
 import React from "react";
 import { excludeClassName } from "../../helpers/exclude";
 import { useTheme } from "../Flowbite/ThemeContext";
@@ -17,6 +17,10 @@ export const ModalBody: FC<ModalBodyProps> = ({ children, ...props }) => {
       className={classNames(theme.base, {
         [theme.popup]: popup,
       })}
+      style={{
+        maxHeight: "calc(100% - 6rem)",
+        ...(theirProps as HTMLProps<'div'>).style
+      }}
       {...theirProps}
     >
       {children}

--- a/src/flowbite/components/Modal/index.tsx
+++ b/src/flowbite/components/Modal/index.tsx
@@ -1,7 +1,6 @@
 import classNames from "classnames";
 import type { ComponentProps, FC, PropsWithChildren } from "react";
-import React from "react";
-import { useEffect, useState } from "react";
+import React, { useEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { excludeClassName } from "../../helpers/exclude";
 import windowExists from "../../helpers/window-exists";
@@ -77,9 +76,7 @@ const ModalComponent: FC<ModalProps> = ({
               <div
                 className={classNames(
                   theme.content.inner,
-                  "overflow-auto",
                   "!h-full",
-                  "scrollbar scrollbar-track-gray-700 scrollbar-thumb-blue-700"
                 )}
               >
                 {children}

--- a/src/flowbite/theme/default.ts
+++ b/src/flowbite/theme/default.ts
@@ -498,15 +498,15 @@ const theme: FlowbiteTheme = {
       inner: "relative rounded-lg bg-white shadow dark:bg-gray-700",
     },
     body: {
-      base: "p-6",
+      base: "p-6 overflow-y-auto scrollbar scrollbar-track-gray-700 scrollbar-thumb-blue-700",
       popup: "pt-0",
     },
     header: {
-      base: "flex items-start justify-between rounded-t dark:border-gray-600 border-b p-5",
+      base: "flex items-center justify-between rounded-t dark:border-gray-600 border-b p-5",
       popup: "!p-2 !border-b-0",
-      title: "text-xl font-medium text-gray-900 dark:text-white",
+      title: "text-xl font-medium text-gray-900 dark:text-white w-full",
       close: {
-        base: "ml-auto inline-flex items-center rounded-lg bg-transparent p-1.5 text-sm text-gray-400 hover:bg-gray-200 hover:text-gray-900 dark:hover:bg-gray-600 dark:hover:text-white",
+        base: "ml-4 inline-flex items-center rounded-lg bg-transparent p-1.5 text-sm text-gray-400 hover:bg-gray-200 hover:text-gray-900 dark:hover:bg-gray-600 dark:hover:text-white",
         icon: "h-5 w-5",
       },
     },

--- a/src/localizationContext.ts
+++ b/src/localizationContext.ts
@@ -1,7 +1,11 @@
-import { createContext } from "react";
+import { createContext, useContext } from "react";
 import { default as enTranslation } from "../locales/en/translation.json";
 // we just need the loc keys
 export const staticTextIds: Record<string, string | number> = enTranslation;
 
 const context = createContext({});
 export default context;
+
+export const useLocalizations = () => {
+  return useContext(context) as typeof enTranslation;
+}


### PR DESCRIPTION
Heya! I finally managed to run the mod manager locally, so I figured I'd give my first contribution to this awesome tool that I love. Hopefully, you'll find it useful. :)

I'm someone who likes to keep a ton of saves on his computer, and sometimes I return to the older ones to give them another spin. Doing that without this manager's "Load Mods From Save" button would be impossible, so I'm grateful that that exists. The only thing that was a bit harder to do is navigate to an older save, especially if it's buried beneath a lot of other files. That and I had to scroll all the way back up to close out of the modal when I'm done.

With that in mind, I decided to take it upon myself to make the improvements I'd like to see, and this is what I'm presenting you in this PR:

- An input field on the Saved Games modal that let's you search through your saves
- A change to how lists in modals are being handled - now, the body of the modal is scrollable, instead of the whole modal (I have tested this in most of the modals in the app and it seems to work fine, but please let me know if you see any issues)
- A small redesign of the Saved Games modal to make the buttons equal width and font size
- (Optional) A minor change is that I've added a `useLocalizations` hook that gives you back a typed object that you can use through the app, so that you don't have to look up the translation key names anymore

https://github.com/user-attachments/assets/724fc7df-54a5-41ac-b8d7-24daeb7160d5

I do realize that some of these changes are maybe a bit too far-reaching, but please give them a chance. They do bring some UX improvements with them. However, if they don't align with your design decisions, please let me know, and I'd be happy to make adjustments that would make you satisfied with the changes.

Cheers for all you've done so far!