### PR TITLE
Add a hover effect to the Saved Game items for better readability

### DIFF
--- a/src/components/SaveGames.tsx
+++ b/src/components/SaveGames.tsx
@@ -86,10 +86,10 @@ const SaveGame = memo((props: SaveGameProps) => {
             </div>
           </Modal.Header>
           <Modal.Body>
-            <div className="grid grid-cols-[3fr_2fr] h-full">
+            <div>
               {saves.map((save) => {
                 return (
-                  <React.Fragment key={save.name}>
+                  <div className="grid grid-cols-[3fr_2fr] h-full p-2 hover:bg-gray-200 hover:text-gray-900 dark:hover:bg-gray-600 dark:hover:text-white" key={save.name}>
                     <div className="self-center leading-relaxed text-gray-500 dark:text-gray-300 h-[40px] truncate content-center">
                       {save.name}
                     </div>
@@ -113,7 +113,7 @@ const SaveGame = memo((props: SaveGameProps) => {
                         {localized.loadModsFromSave}
                       </button>
                     </div>
-                  </React.Fragment>
+                  </div>
                 );
               })}
             </div>


### PR DESCRIPTION
Apologies for the lack of any changes since the last time. I started working and I just never had the energy after work to do anything productive.

That's why the PR I offer now is super small and just builds on top of the Save Game changes that were already made.

This just adds a small hover effect over the Save Games so that it's easier to know which save game buttons you are pressing (something I had trouble with after my change).

![image](https://github.com/user-attachments/assets/9c40c079-df9c-489c-b34b-0a215ab9b1aa)
