### PR TITLE
Add partial linux native support

### DIFF
--- a/src/gameSaves.ts
+++ b/src/gameSaves.ts
@@ -2,22 +2,29 @@ import * as chokidar from "chokidar";
 import { app } from "electron";
 import * as path from "path";
 import * as fs from "fs";
-import { gameToAppDataFolderName } from "./supportedGames";
+import { gameToAppDataFolderName, gameToSteamId } from "./supportedGames";
 import appData from "./appData";
 
 let savesWatcher: chokidar.FSWatcher | undefined;
 
 let saves: GameSave[] = [];
 
-export const getSavesFolderPath = () => { 
-  const appDataPath = app.getPath("appData");
+export const getSavesFolderPath = () => {
+  let appDataPath = app.getPath("appData");
+
+  if (process.platform === "linux") {
+    const homeDir = app.getPath("home");
+    appDataPath = `${homeDir}/.local/share/Steam/steamapps/compatdata/${gameToSteamId[appData.currentGame]}/pfx/drive_c/users/steamuser/AppData/Roaming/`;
+  }
+
   return path.join(
     appDataPath,
     "The Creative Assembly",
     gameToAppDataFolderName[appData.currentGame],
     "save_games"
   );
-};
+}
+
 export const getSaveFiles = async () => {
   saves = [];
   let files: fs.Dirent[] = [];


### PR DESCRIPTION
Fixes #63 
This PR will add a system-level dependency for linux users using a possible native build of the launcher ([proton-tricks](https://github.com/Matoking/protontricks)), though it won't (shouldn't) affect wine users. This patch will only work with the windows, steam version of Warhammer 3 (or other total war games I guess).  

The features enabled are:

- load saved games
- continue from last save game
- launch the game